### PR TITLE
Fix hanging connects to bootstrapper

### DIFF
--- a/pubsub/pubsub-interop.go
+++ b/pubsub/pubsub-interop.go
@@ -166,8 +166,7 @@ func main() {
 	})
 	if bBootstrap {
 		fmt.Println("Bootstrapper running.\nPubSub object instantiated using FloodSubRouter.\nCtrl+C to exit.")
-		for true {
-		}
+		select {}
 	} else {
 		// Now, wait for input from the user, and send that out!
 		scan := bufio.NewScanner(os.Stdin)


### PR DESCRIPTION
Changed pubsub-interop bootstrapper from for-loop infinite loop to select infinite loop.

This issue seems to be the reason for libp2p/go-libp2p-pubsub#195 being filed. The `for true {}` style infinite loop yields no CPU time for processing incoming connections while `select {}` does. 